### PR TITLE
Add remove dead link tasks command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,3 +94,34 @@ api = TodoistAPI(os.getenv("TODOIST_API_KEY"))
 ```
 
 Note that `ipython` is not included in the repo, [I install all my debugging tools via this alias](https://github.com/iloveitaly/dotfiles/blob/e41a309b0ca1f5099bc6d902d0956ba0fc997db1/.aliases#L76-L77) instead of including them in the poetry config.
+
+## New Command: remove_dead_link_tasks
+
+A new command `remove_dead_link_tasks` has been added to handle the removal of tasks older than 180 days with dead links. This command also supports a dry-run flag to log tasks without deleting them.
+
+### Usage
+
+```text
+Usage: remove_dead_link_tasks [OPTIONS]
+
+  Removes tasks older than 180 days with dead links
+
+Options:
+  --dry-run              Dry run the task updates
+  --api-key TEXT         API key. Sourced from TODOIST_API_KEY as well
+  --help                 Show this message and exit.
+```
+
+### Examples
+
+#### Remove tasks with dead links
+
+```shell
+remove_dead_link_tasks --api-key YOUR_API_KEY
+```
+
+#### Dry-run mode
+
+```shell
+remove_dead_link_tasks --api-key YOUR_API_KEY --dry-run
+```


### PR DESCRIPTION
Related to #101

Add a new click command to remove tasks with dead links

* Add a new click command `remove_dead_link_tasks` in `todoist_scheduler/cli.py` to handle the removal of tasks older than 180 days with dead links.
* Add options for `dry-run` and `api-key` to the new command.
* Implement functionality in `todoist_scheduler/main.py` to check for dead links in task titles, log, and delete such tasks.
* Update `readme.md` to include usage instructions for the new command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iloveitaly/todoist-scheduler/issues/101?shareId=14eda76e-4ea6-4a03-8c8b-da9191d547dc).